### PR TITLE
feat: `RLPReader` rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 - [ ] [`SafeCall.sol`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/libraries/SafeCall.sol)
 - [x] [`Types.sol`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/libraries/Types.sol)
 - **RLP:**
-    - [ ] [`RLPReader.sol`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/libraries/rlp/RLPReader.sol)
+    - [x] [`RLPReader.sol`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/libraries/rlp/RLPReader.sol)
     - [ ] [`RLPWriter.sol`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/libraries/rlp/RLPWriter.sol)
 - **Trie (? - Might not be worth with Claim-based withdrawals around the corner.)**
     - [ ] [`MerkleTrie.sol`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/libraries/trie/MerkleTrie.sol)

--- a/src/lib/LibMemory.sol
+++ b/src/lib/LibMemory.sol
@@ -12,9 +12,9 @@ library LibMemory {
     /// @param _offset Offset to start reading from.
     /// @param _length Number of bytes to read.
     /// @return _out Copied bytes.
-    // TODO: The identity precompile may be more efficient here for large lengths.
+    // TODO: The identity precompile may be more efficient here for large lengths. Run some comparisons.
     function mcopy(MemoryPointer _src, uint256 _offset, uint256 _length) internal pure returns (bytes memory _out) {
-        assembly {
+        assembly ("memory-safe") {
             switch _length
             case 0x00 {
                 // Assign `_out` to the zero offset

--- a/src/lib/LibMemory.sol
+++ b/src/lib/LibMemory.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "src/types/Types.sol";
+
+/// @title LibMemory
+/// @notice This library contains utility functions for manipulating and interacting
+///         with memory directly.
+library LibMemory {
+    /// @notice Copies the bytes from a memory location. (wen mcopy?)
+    /// @param _src    Pointer to the location to read from.
+    /// @param _offset Offset to start reading from.
+    /// @param _length Number of bytes to read.
+    /// @return _out Copied bytes.
+    // TODO: The identity precompile may be more efficient here for large lengths.
+    function mcopy(MemoryPointer _src, uint256 _offset, uint256 _length) internal pure returns (bytes memory _out) {
+        assembly {
+            switch _length
+            case 0x00 {
+                // Assign `_out` to the zero offset
+                _out := 0x60
+            }
+            default {
+                // Assign `_out` to the free memory pointer.
+                _out := mload(0x40)
+
+                // Compute the starting offset of the source bytes
+                let src := add(_src, _offset)
+                // Compute the destination offset of the copied bytes
+                let dest := add(_out, 0x20)
+
+                // Copy the bytes
+                let offset := 0x00
+                for { } lt(offset, _length) { offset := add(offset, 0x20) } {
+                    mstore(add(dest, offset), mload(add(src, offset)))
+                }
+
+                // Assign the length of the copied bytes
+                mstore(_out, _length)
+                // Update the free memory pointer
+                mstore(0x40, and(add(_out, add(offset, 0x3F)), not(0x1F)))
+            }
+        }
+    }
+}

--- a/src/lib/LibSafeCall.sol
+++ b/src/lib/LibSafeCall.sol
@@ -14,7 +14,7 @@ library LibSafeCall {
         internal
         returns (bool _success)
     {
-        assembly {
+        assembly ("memory-safe") {
             _success :=
                 call(
                     _gas, // gas

--- a/src/lib/rlp/RLPReader.sol
+++ b/src/lib/rlp/RLPReader.sol
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "src/types/Types.sol";
+
+/**
+ * @custom:attribution https://github.com/hamdiallam/Solidity-RLP
+ * @title RLPReader
+ * @notice RLPReader is a library for parsing RLP-encoded byte arrays into Solidity types. Adapted
+ *         from Solidity-RLP (https://github.com/hamdiallam/Solidity-RLP) by Hamdi Allam with
+ *         various tweaks to improve readability.
+ */
+library RLPReader {
+    /// @notice Max list length that this library will accept.
+    uint256 internal constant MAX_LIST_LENGTH = 32;
+
+    /// @notice Wraps a memory pointer and length into an RLPItem type.
+    /// @param _ptr The memory pointer.
+    /// @param _len The length of the item.
+    /// @return _item The RLPItem.
+    function wrapRLPItem(MemoryPointer _ptr, uint232 _len) internal pure returns (RLPItem _item) {
+        assembly {
+            _item := or(shl(0xE8, _ptr), _len)
+        }
+    }
+
+    /// @notice Unwraps an RLPItem into a memory pointer and length.
+    /// @param _item The RLPItem.
+    /// @return _ptr The memory pointer.
+    /// @return _len The length of the item.
+    function unwrapRLPItem(RLPItem _item) internal pure returns (MemoryPointer _ptr, uint232 _len) {
+        assembly {
+            // The pointer is the 24-bit value in the high-order 24 bits of the item.
+            _ptr := shr(0xE8, _item)
+            // Clean high-order 24 bits from the item to receive the 232 bit length
+            _len := shr(0x18, shl(0x18, _item))
+        }
+    }
+
+    /// @notice Converts bytes to a reference to memory position and length.
+    /// @param _in Input bytes to convert.
+    /// @return _rlpItem Output memory reference.
+    function toRLPItem(bytes memory _in) internal pure returns (RLPItem _rlpItem) {
+        MemoryPointer ptr;
+        uint232 inLen;
+        assembly {
+            ptr := add(_in, 0x20)
+            inLen := mload(_in)
+
+            if iszero(inLen) {
+                // Store "RLPItemEmpty()" selector in scratch space.
+                mstore(0x00, 0xe2ad24d9)
+                // Revert
+                revert(0x1c, 0x04)
+            }
+        }
+        return wrapRLPItem(ptr, inLen);
+    }
+
+    /// @notice Reads an RLP list value into a list of RLP items.
+    /// @param _in RLP list value.
+    /// @return _list Decoded RLP list items.
+    function readList(RLPItem _in) internal pure returns (RLPItem[] memory _list) {
+        (uint256 listOffset, uint256 listLength, RLPItemType itemType) = _decodeLength(_in);
+        (MemoryPointer inPtr, uint240 inLen) = unwrapRLPItem(_in);
+        MemoryPointer listDataOffset;
+
+        assembly {
+            // Assertion: itemType == RLPItemType.LIST_ITEM
+            if iszero(eq(itemType, 0x01)) {
+                // Store the "RLPNotAList()" selector in scratch space.
+                mstore(0x00, 0xf5ad531e)
+                // Revert
+                revert(0x1c, 0x04)
+            }
+
+            if iszero(eq(add(listOffset, listLength), inLen)) {
+                // Store the "RLPInvalidDataRemainder()" selector in scratch space.
+                mstore(0x00, 0xd552ec6e)
+                // Revert
+                revert(0x1c, 0x04)
+            }
+
+            // Assign the list to the free memory pointer.
+            _list := mload(0x40)
+            listDataOffset := add(_list, 0x20)
+        }
+
+        uint256 itemCount = 0;
+        uint256 offset = listOffset;
+        while (offset < inLen) {
+            (uint256 itemOffset, uint256 itemLength,) = _decodeLength(
+                wrapRLPItem(MemoryPointer.wrap(uint24(MemoryPointer.unwrap(inPtr) + offset)), uint232(inLen - offset))
+            );
+            RLPItem inner = wrapRLPItem(
+                MemoryPointer.wrap(uint24(MemoryPointer.unwrap(inPtr) + offset)), uint232(itemLength + itemOffset)
+            );
+
+            assembly {
+                // Assertion: itemCount < MAX_LIST_LENGTH
+                if gt(itemCount, 0x1F) {
+                    // Store the "RLPListTooLong()" selector in scratch space.
+                    mstore(0x00, 0x879dcbe3)
+                    // Revert
+                    revert(0x1c, 0x04)
+                }
+
+                mstore(add(listDataOffset, shl(0x05, itemCount)), inner)
+
+                itemCount := add(itemCount, 0x01)
+                offset := add(offset, add(itemOffset, itemLength))
+            }
+        }
+
+        assembly {
+            // Set the length of the list
+            mstore(_list, itemCount)
+            // Update the free memory pointer
+            mstore(0x40, add(listDataOffset, shl(0x05, itemCount)))
+        }
+    }
+
+    /**
+     * @notice Reads an RLP list value into a list of RLP items.
+     *
+     * @param _in RLP list value.
+     *
+     * @return Decoded RLP list items.
+     */
+    function readList(bytes memory _in) internal pure returns (RLPItem[] memory) {
+        return readList(toRLPItem(_in));
+    }
+
+    /**
+     * @notice Reads an RLP bytes value into bytes.
+     *
+     * @param _in RLP bytes value.
+     *
+     * @return Decoded bytes.
+     */
+    function readBytes(RLPItem _in) internal pure returns (bytes memory) {
+        (uint256 itemOffset, uint256 itemLength, RLPItemType itemType) = _decodeLength(_in);
+        (MemoryPointer inPtr, uint240 inLen) = unwrapRLPItem(_in);
+
+        require(itemType == RLPItemType.DATA_ITEM, "RLPReader: decoded item type for bytes is not a data item");
+
+        require(inLen == itemOffset + itemLength, "RLPReader: bytes value contains an invalid remainder");
+
+        return _copy(inPtr, itemOffset, itemLength);
+    }
+
+    /**
+     * @notice Reads an RLP bytes value into bytes.
+     *
+     * @param _in RLP bytes value.
+     *
+     * @return Decoded bytes.
+     */
+    function readBytes(bytes memory _in) internal pure returns (bytes memory) {
+        return readBytes(toRLPItem(_in));
+    }
+
+    /**
+     * @notice Reads the raw bytes of an RLP item.
+     *
+     * @param _in RLP item to read.
+     *
+     * @return Raw RLP bytes.
+     */
+    function readRawBytes(RLPItem _in) internal pure returns (bytes memory) {
+        (MemoryPointer inPtr, uint240 inLen) = unwrapRLPItem(_in);
+        return _copy(inPtr, 0, inLen);
+    }
+
+    /// @notice Decodes the length of an RLP item.
+    /// @param _in RLP item to decode.
+    /// @return _offset Offset of the encoded data.
+    /// @return _length Length of the encoded data.
+    /// @return _type RLP item type (LIST_ITEM or DATA_ITEM).
+    function _decodeLength(RLPItem _in) private pure returns (uint256 _offset, uint256 _length, RLPItemType _type) {
+        (MemoryPointer inPtr, uint232 inLen) = unwrapRLPItem(_in);
+        assembly {
+            /// @dev Shorthand for reverting with a selector.
+            function revertWithSelector(selector) {
+                // Store selector in scratch space.
+                mstore(0x00, selector)
+                // Revert
+                revert(0x1c, 0x04)
+            }
+
+            // Assertion: inLen > 0
+            // Short-circuit if there's nothing to decode, note that we perform this check when
+            // the user creates an RLP item via toRLPItem, but it's always possible for them to bypass
+            // that function and create an RLP item directly. So we need to check this anyway.
+            if iszero(inLen) {
+                // Store "RLPItemEmpty()" selector in scratch space.
+                mstore(0x00, 0xe2ad24d9)
+                // Revert
+                revert(0x1c, 0x04)
+            }
+
+            // Load the prefix byte of the RLP item.
+            let prefix := byte(0x00, mload(inPtr))
+
+            switch lt(prefix, 0x80)
+            case true {
+                // If the prefix is less than 0x7F, then it is a single byte
+                _offset := 0x00
+                _length := 0x01
+                // RLPItemType.DATA_ITEM = 0x00
+                _type := 0x00
+            }
+            default {
+                switch lt(prefix, 0xB8)
+                case true {
+                    // If the prefix is less than 0xB7, then it is a short string
+                    _offset := 0x01
+                    _length := sub(prefix, 0x80)
+                    // RLPItemType.DATA_ITEM = 0x00
+                    _type := 0x00
+
+                    // Assertion: inLen > _length
+                    if iszero(gt(inLen, _length)) {
+                        // Revert with the "RLPInvalidContentLength()" selector.
+                        revertWithSelector(0x03cbee18)
+                    }
+
+                    // Grab the first byte of the RLP item
+                    let firstByte := byte(0x01, mload(inPtr))
+
+                    // Assertion: _length != 0x01 || firstByte >= 0x80
+                    if and(eq(0x01, _length), lt(firstByte, 0x80)) {
+                        // Revert with the "RLPInvalidPrefix()" selector.
+                        revertWithSelector(0x7f0fdb83)
+                    }
+                }
+                default {
+                    switch lt(prefix, 0xC0)
+                    case true {
+                        // If the prefix is less than 0xBF, then it is a long string
+
+                        // Grab length of the string length figure (in bytes).
+                        let lengthOfLength := sub(prefix, 0xB7)
+
+                        // Assertion: inLen > lengthOfLength
+                        if iszero(gt(inLen, lengthOfLength)) {
+                            // Revert with the "RLPInvalidContentLength()" selector.
+                            revertWithSelector(0x03cbee18)
+                        }
+
+                        // Grab the first byte of the RLP item
+                        let firstByte := byte(0x01, mload(inPtr))
+
+                        // Assertion: firstByte != 0
+                        if iszero(firstByte) {
+                            // Revert with the "RLPNoLeadingZeros()" selector.
+                            revertWithSelector(0xc0b6f8d9)
+                        }
+
+                        // Get the length of the long string
+                        _length := shr(sub(0x100, shl(0x03, _length)), mload(add(inPtr, 0x01)))
+
+                        // Assertion: _length > 55 && inLen > lengthOfLength + _length
+                        if or(lt(_length, 0x38), iszero(gt(inLen, add(lengthOfLength, _length)))) {
+                            // Revert with the "RLPInvalidContentLength()" selector.
+                            revertWithSelector(0x03cbee18)
+                        }
+
+                        _offset := add(0x01, lengthOfLength)
+                        // RLPItemType.DATA_ITEM = 0x00
+                        _type := 0x00
+                    }
+                    default {
+                        switch lt(prefix, 0xF8)
+                        case true {
+                            // If the prefix is <= 0xF7, then it is a short list
+                            _length := sub(prefix, 0xC0)
+
+                            // Assertion: inLen > _length
+                            if iszero(gt(inLen, _length)) {
+                                // Revert with the "RLPInvalidContentLength()" selector.
+                                revertWithSelector(0x03cbee18)
+                            }
+
+                            _offset := 0x01
+                            // RLPItemType.LIST_ITEM = 0x01
+                            _type := 0x01
+                        }
+                        default {
+                            // If the prefix is > 0xF7, then it is a long list
+                            let lengthOfLength := sub(prefix, 0xF7)
+
+                            // Assertion: inLen > lengthOfLength
+                            if iszero(gt(inLen, lengthOfLength)) {
+                                // Revert with the "RLPInvalidContentLength()" selector.
+                                revertWithSelector(0x03cbee18)
+                            }
+
+                            // Get the first byte of the RLP item
+                            let firstByte := byte(0x01, mload(inPtr))
+
+                            // Assertion: firstByte != 0
+                            if iszero(firstByte) {
+                                // Revert with the "RLPNoLeadingZeros()" selector.
+                                revertWithSelector(0xc0b6f8d9)
+                            }
+
+                            // Get the length of the long list
+                            _length := shr(sub(0x100, shl(0x03, lengthOfLength)), mload(add(inPtr, 0x01)))
+
+                            // Assertion: _length > 55 && inLen > lengthOfLength + _length
+                            if or(lt(_length, 0x38), iszero(gt(inLen, add(lengthOfLength, _length)))) {
+                                // Revert with the "RLPInvalidContentLength()" selector.
+                                revertWithSelector(0x03cbee18)
+                            }
+
+                            _offset := add(0x01, lengthOfLength)
+                            // RLPItemType.LIST_ITEM = 0x01
+                            _type := 0x01
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// @notice Copies the bytes from a memory location.
+    /// @param _src    Pointer to the location to read from.
+    /// @param _offset Offset to start reading from.
+    /// @param _length Number of bytes to read.
+    /// @return Copied bytes.
+    function _copy(MemoryPointer _src, uint256 _offset, uint256 _length) private pure returns (bytes memory) {
+        bytes memory out = new bytes(_length);
+        if (_length == 0) {
+            return out;
+        }
+
+        // Mostly based on Solidity's copy_memory_to_memory:
+        // solhint-disable max-line-length
+        // https://github.com/ethereum/solidity/blob/34dd30d71b4da730488be72ff6af7083cf2a91f6/libsolidity/codegen/YulUtilFunctions.cpp#L102-L114
+        uint256 src = MemoryPointer.unwrap(_src) + _offset;
+        assembly {
+            let dest := add(out, 32)
+            let i := 0
+            for { } lt(i, _length) { i := add(i, 32) } { mstore(add(dest, i), mload(add(src, i))) }
+
+            if gt(i, _length) { mstore(add(dest, _length), 0) }
+        }
+
+        return out;
+    }
+}

--- a/src/lib/rlp/RLPReaderLib.sol
+++ b/src/lib/rlp/RLPReaderLib.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.19;
 import "src/types/Types.sol";
 import { LibMemory } from "src/lib/LibMemory.sol";
 
-/// @title RLPReader
-/// @notice RLPReader is a library for parsing RLP-encoded byte arrays into Solidity types. Adapted
+/// @title RLPReaderLib
+/// @notice RLPReaderLib is a library for parsing RLP-encoded byte arrays into Solidity types. Adapted
 ///         from Solidity-RLP (https://github.com/hamdiallam/Solidity-RLP) by Hamdi Allam with
 ///         various tweaks to improve gas efficiency and readability.
 /// @custom:attribution https://github.com/hamdiallam/Solidity-RLP
-library RLPReader {
+library RLPReaderLib {
     ////////////////////////////////////////////////////////////////
     //                         CONSTANTS                          //
     ////////////////////////////////////////////////////////////////

--- a/src/types/Errors.sol
+++ b/src/types/Errors.sol
@@ -17,3 +17,19 @@ error SliceOutOfBounds();
 
 /// @notice Thrown when attempting to call `toRLPItem` on an empty bytes array.
 error RLPItemEmpty();
+
+/// @notice Thrown when the length of an RLP item is too long to be represented
+///         by the content itself.
+error RLPInvalidContentLength();
+
+/// @notice Thrown when an invalid prefix for an RLPItem is encountered.
+error RLPInvalidPrefix();
+
+/// @notice Thrown when an RLP item has unexpected leading zeros.
+error RLPNoLeadingZeros();
+
+error RLPNotAList();
+
+error RLPInvalidDataRemainder();
+
+error RLPListTooLong();

--- a/src/types/Errors.sol
+++ b/src/types/Errors.sol
@@ -15,21 +15,27 @@ error SliceOutOfBounds();
 //                         RLP Errors                         //
 ////////////////////////////////////////////////////////////////
 
-/// @notice Thrown when attempting to call `toRLPItem` on an empty bytes array.
+/// @dev Thrown when attempting to call `toRLPItem` on an empty bytes array.
 error RLPItemEmpty();
 
-/// @notice Thrown when the length of an RLP item is too long to be represented
-///         by the content itself.
+/// @dev Thrown when the length of an RLP item is too long to be represented
+///      by the content itself.
 error RLPInvalidContentLength();
 
-/// @notice Thrown when an invalid prefix for an RLPItem is encountered.
+/// @dev Thrown when an invalid prefix for an RLPItem is encountered.
 error RLPInvalidPrefix();
 
-/// @notice Thrown when an RLP item has unexpected leading zeros.
+/// @dev Thrown when an RLP item has unexpected leading zeros.
 error RLPNoLeadingZeros();
 
+/// @dev Thrown when attempting to read an RLP item that is not a list.
 error RLPNotAList();
 
+/// @dev Thrown when attempting to read an RLP item that is not a data item.
+error RLPNotADataItem();
+
+/// @dev Thrown when an RLP item with an invalid data remainder is encountered.
 error RLPInvalidDataRemainder();
 
+/// @dev Thrown when an RLP list is too long to be represented by the content itself.
 error RLPListTooLong();

--- a/test/lib/LibBytes.t.sol
+++ b/test/lib/LibBytes.t.sol
@@ -33,20 +33,20 @@ contract LibBytes_Test is Test {
         _length = bound(_length, 0, TestArithmetic.saturatingSub(_bytes.length, _start));
 
         // Grab the free memory pointer prior to slicing
-        uint256 ptr = TestUtils.getFreeMemoryPtr();
+        MemoryPointer ptr = TestUtils.getFreeMemoryPtr();
 
         // Perform a slice
         LibBytes.slice(_bytes, _start, _length);
 
         // Grab the free memory pointer after the slice
-        uint256 newPtr = TestUtils.getFreeMemoryPtr();
+        MemoryPointer newPtr = TestUtils.getFreeMemoryPtr();
 
         // Check that the free memory pointer has been properly updated to account for the newly allocated memory.
         // Note that new memory is only allocated if the slice length is non-zero.
         if (_length > 0) {
-            assertEq(newPtr, ptr + 0x20 + TestArithmetic.roundUpTo32(_length));
+            assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0x20 + TestArithmetic.roundUpTo32(_length));
         } else {
-            assertEq(newPtr, ptr);
+            assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr));
         }
     }
 

--- a/test/lib/LibBytes.t.sol
+++ b/test/lib/LibBytes.t.sol
@@ -44,7 +44,9 @@ contract LibBytes_Test is Test {
         // Check that the free memory pointer has been properly updated to account for the newly allocated memory.
         // Note that new memory is only allocated if the slice length is non-zero.
         if (_length > 0) {
-            assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0x20 + TestArithmetic.roundUpTo32(_length));
+            assertEq(
+                MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0x20 + TestArithmetic.roundUpTo32(_length)
+            );
         } else {
             assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr));
         }

--- a/test/lib/LibHashing.t.sol
+++ b/test/lib/LibHashing.t.sol
@@ -42,17 +42,17 @@ contract LibHashing_Test is Test {
     /// @dev Tests that `LibHashing`'s `hash` function is memory-safe.
     function testFuzz_hashWithdrawalTransaction_memorySafety_succeeds(WithdrawalTransaction memory _tx) public {
         // Grab the free memory pointer before the operation.
-        uint256 ptr = TestUtils.getFreeMemoryPtr();
+        MemoryPointer ptr = TestUtils.getFreeMemoryPtr();
 
         // Hash the withdrawal transaction.
         _tx.hash();
 
         // Grab the free memory pointer after the operation.
-        uint256 newPtr = TestUtils.getFreeMemoryPtr();
+        MemoryPointer newPtr = TestUtils.getFreeMemoryPtr();
 
         // Check that the free memory pointer has been properly updated to account for the newly allocated memory.
         // The new pointer should be equal to the old pointer plus the size of the abi-encoded withdrawal transaction
         // in memory.
-        assertEq(newPtr, ptr + 0xE0 + TestArithmetic.roundUpTo32(_tx.data.length));
+        assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0xE0 + TestArithmetic.roundUpTo32(_tx.data.length));
     }
 }

--- a/test/lib/LibHashing.t.sol
+++ b/test/lib/LibHashing.t.sol
@@ -53,6 +53,8 @@ contract LibHashing_Test is Test {
         // Check that the free memory pointer has been properly updated to account for the newly allocated memory.
         // The new pointer should be equal to the old pointer plus the size of the abi-encoded withdrawal transaction
         // in memory.
-        assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0xE0 + TestArithmetic.roundUpTo32(_tx.data.length));
+        assertEq(
+            MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0xE0 + TestArithmetic.roundUpTo32(_tx.data.length)
+        );
     }
 }

--- a/test/lib/LibMemory.t.sol
+++ b/test/lib/LibMemory.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "test/testutils/TestUtils.sol";
+import { TestArithmetic } from "test/testutils/TestArithmetic.sol";
+import { LibMemory } from "src/lib/LibMemory.sol";
+import "src/types/Types.sol";
+
+/// @title LibMemory_Test
+/// @notice Tests for the `LibMemory` library.
+contract LibMemory_Test is Test {
+    /// @dev Tests that `mcopy` correctly copies a given memory region.
+    function test_mcopy_correctness_succeeds(bytes memory _in) public {
+        MemoryPointer inPtr;
+        assembly {
+            inPtr := add(_in, 0x20)
+        }
+        bytes memory copied = LibMemory.mcopy(inPtr, 0, _in.length);
+
+        assertEq(_in, copied);
+        assertEq(_in.length, copied.length);
+    }
+
+    /// @dev Tests that `mcopy` is memory safe.
+    function test_mcopy_memorySafety_succeeds(bytes memory _in) public {
+        MemoryPointer ptr = TestUtils.getFreeMemoryPtr();
+        MemoryPointer inPtr;
+        assembly {
+            inPtr := add(_in, 0x20)
+        }
+        LibMemory.mcopy(inPtr, 0, _in.length);
+        MemoryPointer newPtr = TestUtils.getFreeMemoryPtr();
+
+        // New memory should be allocated if the input length is non-zero.
+        if (_in.length > 0) {
+            assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0x20 + TestArithmetic.roundUpTo32(_in.length));
+        } else {
+            assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr));
+        }
+    }
+}

--- a/test/lib/LibMemory.t.sol
+++ b/test/lib/LibMemory.t.sol
@@ -13,7 +13,7 @@ contract LibMemory_Test is Test {
     /// @dev Tests that `mcopy` correctly copies a given memory region.
     function test_mcopy_correctness_succeeds(bytes memory _in) public {
         MemoryPointer inPtr;
-        assembly {
+        assembly ("memory-safe") {
             inPtr := add(_in, 0x20)
         }
         bytes memory copied = LibMemory.mcopy(inPtr, 0, _in.length);
@@ -26,7 +26,7 @@ contract LibMemory_Test is Test {
     function test_mcopy_memorySafety_succeeds(bytes memory _in) public {
         MemoryPointer ptr = TestUtils.getFreeMemoryPtr();
         MemoryPointer inPtr;
-        assembly {
+        assembly ("memory-safe") {
             inPtr := add(_in, 0x20)
         }
         LibMemory.mcopy(inPtr, 0, _in.length);
@@ -34,7 +34,9 @@ contract LibMemory_Test is Test {
 
         // New memory should be allocated if the input length is non-zero.
         if (_in.length > 0) {
-            assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0x20 + TestArithmetic.roundUpTo32(_in.length));
+            assertEq(
+                MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr) + 0x20 + TestArithmetic.roundUpTo32(_in.length)
+            );
         } else {
             assertEq(MemoryPointer.unwrap(newPtr), MemoryPointer.unwrap(ptr));
         }

--- a/test/lib/rlp/RLPReader.t.sol
+++ b/test/lib/rlp/RLPReader.t.sol
@@ -4,16 +4,16 @@ pragma solidity 0.8.19;
 import { Test } from "forge-std/Test.sol";
 import { TestUtils } from "test/testutils/TestUtils.sol";
 import { TestArithmetic } from "test/testutils/TestArithmetic.sol";
-import { RLPReader } from "src/lib/rlp/RLPReader.sol";
+import { RLPReaderLib } from "src/lib/rlp/RLPReaderLib.sol";
 import "src/types/Types.sol";
 import "src/types/Errors.sol";
 
-/// @notice Tests for the RLPReader library's RLPItem type helpers
-contract RLPReader_RLPItemType_Test is Test {
+/// @notice Tests for the RLPReaderLib.library's RLPItem type helpers
+contract RLPReaderLib_RLPItemType_Test is Test {
     /// @dev Tests that the `wrapRLPItem` and `unwrapRLPItem` functions work as expected.
     function test_wrapUnwrapRLPItem_succeeds(MemoryPointer _ptr, uint232 _len) external {
-        RLPItem item = RLPReader.wrapRLPItem(_ptr, _len);
-        (MemoryPointer _unwrappedPtr, uint232 _unwrappedLen) = RLPReader.unwrapRLPItem(item);
+        RLPItem item = RLPReaderLib.wrapRLPItem(_ptr, _len);
+        (MemoryPointer _unwrappedPtr, uint232 _unwrappedLen) = RLPReaderLib.unwrapRLPItem(item);
         assertEq(MemoryPointer.unwrap(_unwrappedPtr), MemoryPointer.unwrap(_ptr));
         assertEq(_unwrappedLen, _len);
     }
@@ -26,7 +26,7 @@ contract RLPReader_RLPItemType_Test is Test {
         }
 
         // Convert the `_in` bytes to an RLPItem type.
-        RLPItem item = RLPReader.toRLPItem(_in);
+        RLPItem item = RLPReaderLib.toRLPItem(_in);
 
         // Grab the pointer and length of the `_in` bytes.
         MemoryPointer ptr;
@@ -36,133 +36,133 @@ contract RLPReader_RLPItemType_Test is Test {
         uint232 len = uint232(_in.length);
 
         // Check that the pointer and length of the RLPItem match the pointer and length of the input.
-        (MemoryPointer _unwrappedPtr, uint232 _unwrappedLen) = RLPReader.unwrapRLPItem(item);
+        (MemoryPointer _unwrappedPtr, uint232 _unwrappedLen) = RLPReaderLib.unwrapRLPItem(item);
         assertEq(MemoryPointer.unwrap(_unwrappedPtr), MemoryPointer.unwrap(ptr));
         assertEq(_unwrappedLen, len);
     }
 }
 
-/// @notice Tests for the RLPReader library's `readBytes` function.
-contract RLPReader_readBytes_Test is Test {
+/// @notice Tests for the RLPReaderLib.library's `readBytes` function.
+contract RLPReaderLib_readBytes_Test is Test {
     /// @dev Tests that the `readBytes` function returns the correct value for
     ///      a "00" byte string.
     function test_readBytes_bytestring00_succeeds() external {
-        assertEq(RLPReader.readBytes(hex"00"), hex"00");
+        assertEq(RLPReaderLib.readBytes(hex"00"), hex"00");
     }
 
     /// @dev Tests that the `readBytes` function returns the correct value for
     ///      a "01" byte string.
     function test_readBytes_bytestring01_succeeds() external {
-        assertEq(RLPReader.readBytes(hex"01"), hex"01");
+        assertEq(RLPReaderLib.readBytes(hex"01"), hex"01");
     }
 
     /// @dev Tests that the `readBytes` function returns the correct value for
     ///      a "7f" byte string.
     function test_readBytes_bytestring7f_succeeds() external {
-        assertEq(RLPReader.readBytes(hex"7f"), hex"7f");
+        assertEq(RLPReaderLib.readBytes(hex"7f"), hex"7f");
     }
 
     /// @dev Tests that the `readBytes` function reverts if it is passed an
     ///      RLPItem that is not a data item.
     function test_readBytes_revertListItem_reverts() external {
         vm.expectRevert(RLPNotADataItem.selector);
-        RLPReader.readBytes(hex"c7c0c1c0c3c0c1c0");
+        RLPReaderLib.readBytes(hex"c7c0c1c0c3c0c1c0");
     }
 
     /// @dev Tests that the `readBytes` function reverts if it is passed an
     ///      RLPItem that has an invalid string length.
     function test_readBytes_invalidStringLength_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readBytes(hex"b9");
+        RLPReaderLib.readBytes(hex"b9");
     }
 
     /// @dev Tests that the `readBytes` function reverts if it is passed an
     ///      RLPItem that has an invalid list length.
     function test_readBytes_invalidListLength_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readBytes(hex"ff");
+        RLPReaderLib.readBytes(hex"ff");
     }
 
     /// @dev Tests that the `readBytes` function reverts if it is passed an
     ///      RLPItem that has an invalid data remainder.
     function test_readBytes_invalidRemainder_reverts() external {
         vm.expectRevert(RLPInvalidDataRemainder.selector);
-        RLPReader.readBytes(hex"800a");
+        RLPReaderLib.readBytes(hex"800a");
     }
 
     /// @dev Tests that the `readBytes` function reverts if it is passed an
     ///      RLPItem that has an invalid prefix.
     function test_readBytes_invalidPrefix_reverts() external {
         vm.expectRevert(RLPInvalidPrefix.selector);
-        RLPReader.readBytes(hex"810a");
+        RLPReaderLib.readBytes(hex"810a");
     }
 }
 
-/// @notice Tests for the RLPReader library's `readList` function.
-contract RLPReader_readList_Test is Test {
+/// @notice Tests for the RLPReaderLib.library's `readList` function.
+contract RLPReaderLib_readList_Test is Test {
     /// @dev Tests that the `readList` function returns the correct value for
     ///      an empty list.
     function test_readList_empty_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(hex"c0");
+        RLPItem[] memory list = RLPReaderLib.readList(hex"c0");
         assertEq(list.length, 0);
     }
 
     /// @dev Tests that the `readList` function returns the correct value for
     ///      a list with multiple items.
     function test_readList_multiList_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(hex"c6827a77c10401");
+        RLPItem[] memory list = RLPReaderLib.readList(hex"c6827a77c10401");
         assertEq(list.length, 3);
 
-        assertEq(RLPReader.readRawBytes(list[0]), hex"827a77");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"c104");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"01");
+        assertEq(RLPReaderLib.readRawBytes(list[0]), hex"827a77");
+        assertEq(RLPReaderLib.readRawBytes(list[1]), hex"c104");
+        assertEq(RLPReaderLib.readRawBytes(list[2]), hex"01");
     }
 
     /// @dev Tests that the `readList` function returns the correct value for
     ///      a short list with 11 items.
     function test_readList_shortListMax1_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(
+        RLPItem[] memory list = RLPReaderLib.readList(
             hex"f784617364668471776572847a78637684617364668471776572847a78637684617364668471776572847a78637684617364668471776572"
         );
 
         assertEq(list.length, 11);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"8471776572");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"847a786376");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[4]), hex"8471776572");
-        assertEq(RLPReader.readRawBytes(list[5]), hex"847a786376");
-        assertEq(RLPReader.readRawBytes(list[6]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[7]), hex"8471776572");
-        assertEq(RLPReader.readRawBytes(list[8]), hex"847a786376");
-        assertEq(RLPReader.readRawBytes(list[9]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[10]), hex"8471776572");
+        assertEq(RLPReaderLib.readRawBytes(list[0]), hex"8461736466");
+        assertEq(RLPReaderLib.readRawBytes(list[1]), hex"8471776572");
+        assertEq(RLPReaderLib.readRawBytes(list[2]), hex"847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[3]), hex"8461736466");
+        assertEq(RLPReaderLib.readRawBytes(list[4]), hex"8471776572");
+        assertEq(RLPReaderLib.readRawBytes(list[5]), hex"847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[6]), hex"8461736466");
+        assertEq(RLPReaderLib.readRawBytes(list[7]), hex"8471776572");
+        assertEq(RLPReaderLib.readRawBytes(list[8]), hex"847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[9]), hex"8461736466");
+        assertEq(RLPReaderLib.readRawBytes(list[10]), hex"8471776572");
     }
 
     /// @dev Tests that the `readList` function returns the correct value for
     ///      a long list with 4 items.
     function test_readList_longList1_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(
+        RLPItem[] memory list = RLPReaderLib.readList(
             hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
 
         assertEq(list.length, 4);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReaderLib.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
     }
 
     /// @dev Tests that the `readList` function returns the correct value for
     ///      a long list with 32 items.
     function test_readList_longList2_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(
+        RLPItem[] memory list = RLPReaderLib.readList(
             hex"f90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
         assertEq(list.length, 32);
 
         for (uint256 i = 0; i < 32; i++) {
-            assertEq(RLPReader.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
+            assertEq(RLPReaderLib.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
         }
     }
 
@@ -170,86 +170,86 @@ contract RLPReader_readList_Test is Test {
     ///      than 32 items.
     function test_readList_listLongerThan32Elements_reverts() external {
         vm.expectRevert(RLPListTooLong.selector);
-        RLPReader.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
+        RLPReaderLib.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
     }
 
     /// @dev Tests that the `readList` function returns the correct value when
     ///      passed a list of lists.
     function test_readList_listOfLists_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(hex"c4c2c0c0c0");
+        RLPItem[] memory list = RLPReaderLib.readList(hex"c4c2c0c0c0");
         assertEq(list.length, 2);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"c2c0c0");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"c0");
+        assertEq(RLPReaderLib.readRawBytes(list[0]), hex"c2c0c0");
+        assertEq(RLPReaderLib.readRawBytes(list[1]), hex"c0");
     }
 
     /// @dev Tests that the `readList` function returns the correct value when
     ///      passed a list of lists.
     function test_readList_listOfLists2_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(hex"c7c0c1c0c3c0c1c0");
+        RLPItem[] memory list = RLPReaderLib.readList(hex"c7c0c1c0c3c0c1c0");
         assertEq(list.length, 3);
 
-        assertEq(RLPReader.readRawBytes(list[0]), hex"c0");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"c1c0");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"c3c0c1c0");
+        assertEq(RLPReaderLib.readRawBytes(list[0]), hex"c0");
+        assertEq(RLPReaderLib.readRawBytes(list[1]), hex"c1c0");
+        assertEq(RLPReaderLib.readRawBytes(list[2]), hex"c3c0c1c0");
     }
 
     /// @dev Tests that the `readList` function returns the correct value when
     ///      passed a dictionary (array of key/value pairs)
     function test_readList_dictTest1_succeeds() external {
-        RLPItem[] memory list = RLPReader.readList(
+        RLPItem[] memory list = RLPReaderLib.readList(
             hex"ecca846b6579318476616c31ca846b6579328476616c32ca846b6579338476616c33ca846b6579348476616c34"
         );
         assertEq(list.length, 4);
 
-        assertEq(RLPReader.readRawBytes(list[0]), hex"ca846b6579318476616c31");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"ca846b6579328476616c32");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"ca846b6579338476616c33");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"ca846b6579348476616c34");
+        assertEq(RLPReaderLib.readRawBytes(list[0]), hex"ca846b6579318476616c31");
+        assertEq(RLPReaderLib.readRawBytes(list[1]), hex"ca846b6579328476616c32");
+        assertEq(RLPReaderLib.readRawBytes(list[2]), hex"ca846b6579338476616c33");
+        assertEq(RLPReaderLib.readRawBytes(list[3]), hex"ca846b6579348476616c34");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a short list
     ///      with an invalid content length.
     function test_readList_invalidShortList_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"efdebd");
+        RLPReaderLib.readList(hex"efdebd");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a long string
     ///      with an invalid content length.
     function test_readList_longStringLength_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"efb83600");
+        RLPReaderLib.readList(hex"efb83600");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that is
     ///      not long enough.
     function test_readList_notLongEnough_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        RLPReaderLib.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
     function test_readList_int32Overflow_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"bf0f000000000000021111");
+        RLPReaderLib.readList(hex"bf0f000000000000021111");
     }
 
     function test_readList_int32Overflow2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"ff0f000000000000021111");
+        RLPReaderLib.readList(hex"ff0f000000000000021111");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      begins with a leading zero.
     function test_readList_incorrectLengthInArray_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
-        RLPReader.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
+        RLPReaderLib.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      begins with a leading zero.
     function test_readList_leadingZerosInLongLengthArray1_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
-        RLPReader.readList(
+        RLPReaderLib.readList(
             hex"b90040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
@@ -258,14 +258,14 @@ contract RLPReader_readList_Test is Test {
     ///      begins with a leading zero.
     function test_readList_leadingZerosInLongLengthArray2_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
-        RLPReader.readList(hex"b800");
+        RLPReaderLib.readList(hex"b800");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      begins with a leading zero.
     function test_readList_leadingZerosInLongLengthList1_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
-        RLPReader.readList(
+        RLPReaderLib.readList(
             hex"fb00000040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
@@ -274,70 +274,70 @@ contract RLPReader_readList_Test is Test {
     ///      has an invalid length.
     function test_readList_nonOptimalLongLengthArray1_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"b81000112233445566778899aabbccddeeff");
+        RLPReaderLib.readList(hex"b81000112233445566778899aabbccddeeff");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid length.
     function test_readList_nonOptimalLongLengthArray2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"b801ff");
+        RLPReaderLib.readList(hex"b801ff");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid length.
     function test_readList_invalidValue_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"91");
+        RLPReaderLib.readList(hex"91");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid data remainder.
     function test_readList_invalidRemainder_reverts() external {
         vm.expectRevert(RLPInvalidDataRemainder.selector);
-        RLPReader.readList(hex"c000");
+        RLPReaderLib.readList(hex"c000");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid content length.
     function test_readList_notEnoughContentForString1_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"ba010000aabbccddeeff");
+        RLPReaderLib.readList(hex"ba010000aabbccddeeff");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid content length.
     function test_readList_notEnoughContentForString2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"b840ffeeddccbbaa99887766554433221100");
+        RLPReaderLib.readList(hex"b840ffeeddccbbaa99887766554433221100");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid content length.
     function test_readList_notEnoughContentForList1_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"f90180");
+        RLPReaderLib.readList(hex"f90180");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid content length.
     function test_readList_notEnoughContentForList2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"ffffffffffffffffff0001020304050607");
+        RLPReaderLib.readList(hex"ffffffffffffffffff0001020304050607");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid content length.
     function test_readList_longStringLessThan56Bytes_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"b80100");
+        RLPReaderLib.readList(hex"b80100");
     }
 
     /// @dev Tests that the `readList` function reverts when passed a list that
     ///      has an invalid content length.
     function test_readList_longListLessThan56Bytes_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
-        RLPReader.readList(hex"f80100");
+        RLPReaderLib.readList(hex"f80100");
     }
 
     /// @dev Tests that the `readList` function is memory safe.
@@ -346,7 +346,7 @@ contract RLPReader_readList_Test is Test {
         bytes memory listBytes =
             hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376";
         MemoryPointer ptr = TestUtils.getFreeMemoryPtr();
-        RLPReader.readList(listBytes);
+        RLPReaderLib.readList(listBytes);
         MemoryPointer newPtr = TestUtils.getFreeMemoryPtr();
 
         // Check that the free memory pointer was properly updated

--- a/test/lib/rlp/RLPReader.t.sol
+++ b/test/lib/rlp/RLPReader.t.sol
@@ -8,6 +8,40 @@ import { RLPReader } from "src/lib/rlp/RLPReader.sol";
 import "src/types/Types.sol";
 import "src/types/Errors.sol";
 
+/// @notice Tests for the RLPReader library's RLPItem type helpers
+contract RLPReader_RLPItemType_Test is Test {
+    /// @dev Tests that the `wrapRLPItem` and `unwrapRLPItem` functions work as expected.
+    function test_wrapUnwrapRLPItem_succeeds(MemoryPointer _ptr, uint232 _len) external {
+        RLPItem item = RLPReader.wrapRLPItem(_ptr, _len);
+        (MemoryPointer _unwrappedPtr, uint232 _unwrappedLen) = RLPReader.unwrapRLPItem(item);
+        assertEq(MemoryPointer.unwrap(_unwrappedPtr), MemoryPointer.unwrap(_ptr));
+        assertEq(_unwrappedLen, _len);
+    }
+
+    /// @dev Tests that the `toRLPItem` function works as expected.
+    function test_toRLPItem_succeeds(bytes memory _in) external {
+        // If the input is empty, expect a revert.
+        if (_in.length == 0) {
+            vm.expectRevert(RLPItemEmpty.selector);
+        }
+
+        // Convert the `_in` bytes to an RLPItem type.
+        RLPItem item = RLPReader.toRLPItem(_in);
+
+        // Grab the pointer and length of the `_in` bytes.
+        MemoryPointer ptr;
+        assembly {
+            ptr := add(_in, 0x20)
+        }
+        uint232 len = uint232(_in.length);
+
+        // Check that the pointer and length of the RLPItem match the pointer and length of the input.
+        (MemoryPointer _unwrappedPtr, uint232 _unwrappedLen) = RLPReader.unwrapRLPItem(item);
+        assertEq(MemoryPointer.unwrap(_unwrappedPtr), MemoryPointer.unwrap(ptr));
+        assertEq(_unwrappedLen, len);
+    }
+}
+
 /// @notice Tests for the RLPReader library's `readBytes` function.
 contract RLPReader_readBytes_Test is Test {
     /// @dev Tests that the `readBytes` function returns the correct value for

--- a/test/lib/rlp/RLPReader.t.sol
+++ b/test/lib/rlp/RLPReader.t.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import { Test, stdError } from "forge-std/Test.sol";
+import { RLPReader } from "src/lib/rlp/RLPReader.sol";
+import "src/types/Types.sol";
+import "src/types/Errors.sol";
+
+contract RLPReader_readBytes_Test is Test {
+    function test_type_wrap_succeeds() external {
+        emit log_bytes32(RLPItem.unwrap(RLPReader.wrapRLPItem(MemoryPointer.wrap(type(uint24).max), type(uint32).max)));
+    }
+
+    function test_readBytes_bytestring00_succeeds() external {
+        assertEq(RLPReader.readBytes(hex"00"), hex"00");
+    }
+
+    function test_readBytes_bytestring01_succeeds() external {
+        assertEq(RLPReader.readBytes(hex"01"), hex"01");
+    }
+
+    function test_readBytes_bytestring7f_succeeds() external {
+        assertEq(RLPReader.readBytes(hex"7f"), hex"7f");
+    }
+
+    function test_readBytes_revertListItem_reverts() external {
+        vm.expectRevert("RLPReader: decoded item type for bytes is not a data item");
+        RLPReader.readBytes(hex"c7c0c1c0c3c0c1c0");
+    }
+
+    function test_readBytes_invalidStringLength_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readBytes(hex"b9");
+    }
+
+    function test_readBytes_invalidListLength_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readBytes(hex"ff");
+    }
+
+    function test_readBytes_invalidRemainder_reverts() external {
+        vm.expectRevert("RLPReader: bytes value contains an invalid remainder");
+        RLPReader.readBytes(hex"800a");
+    }
+
+    function test_readBytes_invalidPrefix_reverts() external {
+        vm.expectRevert(RLPInvalidPrefix.selector);
+        RLPReader.readBytes(hex"810a");
+    }
+}
+
+contract RLPReader_readList_Test is Test {
+    function test_readList_empty_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(hex"c0");
+        assertEq(list.length, 0);
+    }
+
+    function test_readList_multiList_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(hex"c6827a77c10401");
+        assertEq(list.length, 3);
+
+        assertEq(RLPReader.readRawBytes(list[0]), hex"827a77");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"c104");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"01");
+    }
+
+    function test_readList_shortListMax1_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(
+            hex"f784617364668471776572847a78637684617364668471776572847a78637684617364668471776572847a78637684617364668471776572"
+        );
+
+        assertEq(list.length, 11);
+        assertEq(RLPReader.readRawBytes(list[0]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"847a786376");
+        assertEq(RLPReader.readRawBytes(list[3]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[4]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[5]), hex"847a786376");
+        assertEq(RLPReader.readRawBytes(list[6]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[7]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[8]), hex"847a786376");
+        assertEq(RLPReader.readRawBytes(list[9]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[10]), hex"8471776572");
+    }
+
+    function test_readList_longList1_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(
+            hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
+        );
+
+        assertEq(list.length, 4);
+        assertEq(RLPReader.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
+    }
+
+    function test_readList_longList2_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(
+            hex"f90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
+        );
+        assertEq(list.length, 32);
+
+        for (uint256 i = 0; i < 32; i++) {
+            assertEq(RLPReader.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
+        }
+    }
+
+    function test_readList_listLongerThan32Elements_reverts() external {
+        vm.expectRevert(RLPListTooLong.selector);
+        RLPReader.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
+    }
+
+    function test_readList_listOfLists_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(hex"c4c2c0c0c0");
+        assertEq(list.length, 2);
+        assertEq(RLPReader.readRawBytes(list[0]), hex"c2c0c0");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"c0");
+    }
+
+    function test_readList_listOfLists2_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(hex"c7c0c1c0c3c0c1c0");
+        assertEq(list.length, 3);
+
+        assertEq(RLPReader.readRawBytes(list[0]), hex"c0");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"c1c0");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"c3c0c1c0");
+    }
+
+    function test_readList_dictTest1_succeeds() external {
+        RLPItem[] memory list = RLPReader.readList(
+            hex"ecca846b6579318476616c31ca846b6579328476616c32ca846b6579338476616c33ca846b6579348476616c34"
+        );
+        assertEq(list.length, 4);
+
+        assertEq(RLPReader.readRawBytes(list[0]), hex"ca846b6579318476616c31");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"ca846b6579328476616c32");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"ca846b6579338476616c33");
+        assertEq(RLPReader.readRawBytes(list[3]), hex"ca846b6579348476616c34");
+    }
+
+    function test_readList_invalidShortList_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"efdebd");
+    }
+
+    function test_readList_longStringLength_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"efb83600");
+    }
+
+    function test_readList_notLongEnough_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
+
+    function test_readList_int32Overflow_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"bf0f000000000000021111");
+    }
+
+    function test_readList_int32Overflow2_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"ff0f000000000000021111");
+    }
+
+    function test_readList_incorrectLengthInArray_reverts() external {
+        vm.expectRevert(RLPNoLeadingZeros.selector);
+        RLPReader.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
+    }
+
+    function test_readList_leadingZerosInLongLengthArray1_reverts() external {
+        vm.expectRevert(RLPNoLeadingZeros.selector);
+        RLPReader.readList(
+            hex"b90040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        );
+    }
+
+    function test_readList_leadingZerosInLongLengthArray2_reverts() external {
+        vm.expectRevert(RLPNoLeadingZeros.selector);
+        RLPReader.readList(hex"b800");
+    }
+
+    function test_readList_leadingZerosInLongLengthList1_reverts() external {
+        vm.expectRevert(RLPNoLeadingZeros.selector);
+        RLPReader.readList(
+            hex"fb00000040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        );
+    }
+
+    function test_readList_nonOptimalLongLengthArray1_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"b81000112233445566778899aabbccddeeff");
+    }
+
+    function test_readList_nonOptimalLongLengthArray2_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"b801ff");
+    }
+
+    function test_readList_invalidValue_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"91");
+    }
+
+    function test_readList_invalidRemainder_reverts() external {
+        vm.expectRevert(RLPInvalidDataRemainder.selector);
+        RLPReader.readList(hex"c000");
+    }
+
+    function test_readList_notEnoughContentForString1_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"ba010000aabbccddeeff");
+    }
+
+    function test_readList_notEnoughContentForString2_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"b840ffeeddccbbaa99887766554433221100");
+    }
+
+    function test_readList_notEnoughContentForList1_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"f90180");
+    }
+
+    function test_readList_notEnoughContentForList2_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"ffffffffffffffffff0001020304050607");
+    }
+
+    function test_readList_longStringLessThan56Bytes_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"b80100");
+    }
+
+    function test_readList_longListLessThan56Bytes_reverts() external {
+        vm.expectRevert(RLPInvalidContentLength.selector);
+        RLPReader.readList(hex"f80100");
+    }
+}

--- a/test/lib/rlp/RLPReader.t.sol
+++ b/test/lib/rlp/RLPReader.t.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import { Test, stdError } from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "test/testutils/TestUtils.sol";
+import { TestArithmetic } from "test/testutils/TestArithmetic.sol";
 import { RLPReader } from "src/lib/rlp/RLPReader.sol";
 import "src/types/Types.sol";
 import "src/types/Errors.sol";
@@ -157,6 +159,8 @@ contract RLPReader_readList_Test is Test {
         assertEq(RLPReader.readRawBytes(list[2]), hex"c3c0c1c0");
     }
 
+    /// @dev Tests that the `readList` function returns the correct value when
+    ///      passed a dictionary (array of key/value pairs)
     function test_readList_dictTest1_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(
             hex"ecca846b6579318476616c31ca846b6579328476616c32ca846b6579338476616c33ca846b6579348476616c34"
@@ -190,7 +194,6 @@ contract RLPReader_readList_Test is Test {
         RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
-    /// @dev Tests that the `readList` function reverts when passed a list that is
     function test_readList_int32Overflow_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"bf0f000000000000021111");
@@ -201,11 +204,15 @@ contract RLPReader_readList_Test is Test {
         RLPReader.readList(hex"ff0f000000000000021111");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      begins with a leading zero.
     function test_readList_incorrectLengthInArray_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
         RLPReader.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      begins with a leading zero.
     function test_readList_leadingZerosInLongLengthArray1_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
         RLPReader.readList(
@@ -213,11 +220,15 @@ contract RLPReader_readList_Test is Test {
         );
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      begins with a leading zero.
     function test_readList_leadingZerosInLongLengthArray2_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
         RLPReader.readList(hex"b800");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      begins with a leading zero.
     function test_readList_leadingZerosInLongLengthList1_reverts() external {
         vm.expectRevert(RLPNoLeadingZeros.selector);
         RLPReader.readList(
@@ -225,53 +236,89 @@ contract RLPReader_readList_Test is Test {
         );
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid length.
     function test_readList_nonOptimalLongLengthArray1_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"b81000112233445566778899aabbccddeeff");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid length.
     function test_readList_nonOptimalLongLengthArray2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"b801ff");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid length.
     function test_readList_invalidValue_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"91");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid data remainder.
     function test_readList_invalidRemainder_reverts() external {
         vm.expectRevert(RLPInvalidDataRemainder.selector);
         RLPReader.readList(hex"c000");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid content length.
     function test_readList_notEnoughContentForString1_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"ba010000aabbccddeeff");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid content length.
     function test_readList_notEnoughContentForString2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"b840ffeeddccbbaa99887766554433221100");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid content length.
     function test_readList_notEnoughContentForList1_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"f90180");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid content length.
     function test_readList_notEnoughContentForList2_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"ffffffffffffffffff0001020304050607");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid content length.
     function test_readList_longStringLessThan56Bytes_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"b80100");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that
+    ///      has an invalid content length.
     function test_readList_longListLessThan56Bytes_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"f80100");
+    }
+
+    /// @dev Tests that the `readList` function is memory safe.
+    /// TODO: Strengthen this test
+    function test_readList_memorySafety_succeeds() external {
+        bytes memory listBytes =
+            hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376";
+        MemoryPointer ptr = TestUtils.getFreeMemoryPtr();
+        RLPReader.readList(listBytes);
+        MemoryPointer newPtr = TestUtils.getFreeMemoryPtr();
+
+        // Check that the free memory pointer was properly updated
+        assertEq(
+            MemoryPointer.unwrap(newPtr),
+            MemoryPointer.unwrap(ptr) + 0x20 + 0x80 // ptr + 0x20 (length) + 0x80 (data)
+        );
     }
 }

--- a/test/lib/rlp/RLPReader.t.sol
+++ b/test/lib/rlp/RLPReader.t.sol
@@ -6,55 +6,73 @@ import { RLPReader } from "src/lib/rlp/RLPReader.sol";
 import "src/types/Types.sol";
 import "src/types/Errors.sol";
 
+/// @notice Tests for the RLPReader library's `readBytes` function.
 contract RLPReader_readBytes_Test is Test {
-    function test_type_wrap_succeeds() external {
-        emit log_bytes32(RLPItem.unwrap(RLPReader.wrapRLPItem(MemoryPointer.wrap(type(uint24).max), type(uint32).max)));
-    }
-
+    /// @dev Tests that the `readBytes` function returns the correct value for
+    ///      a "00" byte string.
     function test_readBytes_bytestring00_succeeds() external {
         assertEq(RLPReader.readBytes(hex"00"), hex"00");
     }
 
+    /// @dev Tests that the `readBytes` function returns the correct value for
+    ///      a "01" byte string.
     function test_readBytes_bytestring01_succeeds() external {
         assertEq(RLPReader.readBytes(hex"01"), hex"01");
     }
 
+    /// @dev Tests that the `readBytes` function returns the correct value for
+    ///      a "7f" byte string.
     function test_readBytes_bytestring7f_succeeds() external {
         assertEq(RLPReader.readBytes(hex"7f"), hex"7f");
     }
 
+    /// @dev Tests that the `readBytes` function reverts if it is passed an
+    ///      RLPItem that is not a data item.
     function test_readBytes_revertListItem_reverts() external {
-        vm.expectRevert("RLPReader: decoded item type for bytes is not a data item");
+        vm.expectRevert(RLPNotADataItem.selector);
         RLPReader.readBytes(hex"c7c0c1c0c3c0c1c0");
     }
 
+    /// @dev Tests that the `readBytes` function reverts if it is passed an
+    ///      RLPItem that has an invalid string length.
     function test_readBytes_invalidStringLength_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readBytes(hex"b9");
     }
 
+    /// @dev Tests that the `readBytes` function reverts if it is passed an
+    ///      RLPItem that has an invalid list length.
     function test_readBytes_invalidListLength_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readBytes(hex"ff");
     }
 
+    /// @dev Tests that the `readBytes` function reverts if it is passed an
+    ///      RLPItem that has an invalid data remainder.
     function test_readBytes_invalidRemainder_reverts() external {
-        vm.expectRevert("RLPReader: bytes value contains an invalid remainder");
+        vm.expectRevert(RLPInvalidDataRemainder.selector);
         RLPReader.readBytes(hex"800a");
     }
 
+    /// @dev Tests that the `readBytes` function reverts if it is passed an
+    ///      RLPItem that has an invalid prefix.
     function test_readBytes_invalidPrefix_reverts() external {
         vm.expectRevert(RLPInvalidPrefix.selector);
         RLPReader.readBytes(hex"810a");
     }
 }
 
+/// @notice Tests for the RLPReader library's `readList` function.
 contract RLPReader_readList_Test is Test {
+    /// @dev Tests that the `readList` function returns the correct value for
+    ///      an empty list.
     function test_readList_empty_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(hex"c0");
         assertEq(list.length, 0);
     }
 
+    /// @dev Tests that the `readList` function returns the correct value for
+    ///      a list with multiple items.
     function test_readList_multiList_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(hex"c6827a77c10401");
         assertEq(list.length, 3);
@@ -64,6 +82,8 @@ contract RLPReader_readList_Test is Test {
         assertEq(RLPReader.readRawBytes(list[2]), hex"01");
     }
 
+    /// @dev Tests that the `readList` function returns the correct value for
+    ///      a short list with 11 items.
     function test_readList_shortListMax1_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(
             hex"f784617364668471776572847a78637684617364668471776572847a78637684617364668471776572847a78637684617364668471776572"
@@ -83,6 +103,8 @@ contract RLPReader_readList_Test is Test {
         assertEq(RLPReader.readRawBytes(list[10]), hex"8471776572");
     }
 
+    /// @dev Tests that the `readList` function returns the correct value for
+    ///      a long list with 4 items.
     function test_readList_longList1_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(
             hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
@@ -95,6 +117,8 @@ contract RLPReader_readList_Test is Test {
         assertEq(RLPReader.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
     }
 
+    /// @dev Tests that the `readList` function returns the correct value for
+    ///      a long list with 32 items.
     function test_readList_longList2_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(
             hex"f90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
@@ -106,11 +130,15 @@ contract RLPReader_readList_Test is Test {
         }
     }
 
+    /// @dev Tests that the `readList` function reverts when the list is longer
+    ///      than 32 items.
     function test_readList_listLongerThan32Elements_reverts() external {
         vm.expectRevert(RLPListTooLong.selector);
         RLPReader.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
     }
 
+    /// @dev Tests that the `readList` function returns the correct value when
+    ///      passed a list of lists.
     function test_readList_listOfLists_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(hex"c4c2c0c0c0");
         assertEq(list.length, 2);
@@ -118,6 +146,8 @@ contract RLPReader_readList_Test is Test {
         assertEq(RLPReader.readRawBytes(list[1]), hex"c0");
     }
 
+    /// @dev Tests that the `readList` function returns the correct value when
+    ///      passed a list of lists.
     function test_readList_listOfLists2_succeeds() external {
         RLPItem[] memory list = RLPReader.readList(hex"c7c0c1c0c3c0c1c0");
         assertEq(list.length, 3);
@@ -139,21 +169,28 @@ contract RLPReader_readList_Test is Test {
         assertEq(RLPReader.readRawBytes(list[3]), hex"ca846b6579348476616c34");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a short list
+    ///      with an invalid content length.
     function test_readList_invalidShortList_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"efdebd");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a long string
+    ///      with an invalid content length.
     function test_readList_longStringLength_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"efb83600");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that is
+    ///      not long enough.
     function test_readList_notLongEnough_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
+    /// @dev Tests that the `readList` function reverts when passed a list that is
     function test_readList_int32Overflow_reverts() external {
         vm.expectRevert(RLPInvalidContentLength.selector);
         RLPReader.readList(hex"bf0f000000000000021111");

--- a/test/testutils/TestUtils.sol
+++ b/test/testutils/TestUtils.sol
@@ -9,7 +9,7 @@ library TestUtils {
     /// @notice Gets the free memory pointer
     /// @return _ptr The free memory pointer
     function getFreeMemoryPtr() internal pure returns (MemoryPointer _ptr) {
-        assembly {
+        assembly ("memory-safe") {
             _ptr := mload(0x40)
         }
     }

--- a/test/testutils/TestUtils.sol
+++ b/test/testutils/TestUtils.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import "src/types/Types.sol";
+
 /// @title TestUtils
 /// @notice Various utility functions for testing.
 library TestUtils {
     /// @notice Gets the free memory pointer
     /// @return _ptr The free memory pointer
-    function getFreeMemoryPtr() internal pure returns (uint256 _ptr) {
+    function getFreeMemoryPtr() internal pure returns (MemoryPointer _ptr) {
         assembly {
             _ptr := mload(0x40)
         }


### PR DESCRIPTION
# Overview

Adds a modern version of `contracts-bedrock`'s `RLPReader` contract.

## Motivation

`contracts-bedrock`'s `RLPReader` contract is very outdated, and has several painful inefficiencies. Namely, `readList` currently expands memory by ***2048*** bytes each time it is called, and most of that memory goes entirely unused due to the fact that the free memory pointer is never updated. 

## Solution

Rewrite `RLPReader`.

## Meme

![image](https://user-images.githubusercontent.com/8406232/224567124-5900ebba-3cc6-4b21-bf26-76cdfaa324d7.png)
